### PR TITLE
Support backporting PRs from forked repos

### DIFF
--- a/workflow-templates/backport.yml
+++ b/workflow-templates/backport.yml
@@ -8,8 +8,7 @@ on:
   # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
   pull_request_target:
     types: [closed]
-  issue_comment:
-    types: [created]
+  # See also commands.yml for the /backport triggered variant of this workflow.
 
 jobs:
   # NOTE(negz): I tested many backport GitHub actions before landing on this
@@ -20,34 +19,8 @@ jobs:
   # and that PRs _must_ be labelled before they're merged to trigger a backport.
   open-pr:
     runs-on: ubuntu-18.04
-    if: >
-      (
-        github.event_name == 'pull_request_target'
-        && github.event.pull_request.merged
-      ) || (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        startsWith(github.event.comment.body, '/backport')
-      )
+    if: github.event.pull_request.merged
     steps:
-      - name: React to Command
-        uses: actions/github-script@v4
-        if: >
-          github.event_name == 'issue_comment' &&
-          github.event.issue.pull_request &&
-          startsWith(github.event.comment.body, '/backport')
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            // Ack that we saw the comment.
-            github.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: "eyes"
-            })
-            console.log("Reacted to comment.")
-
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/workflow-templates/backport.yml
+++ b/workflow-templates/backport.yml
@@ -1,8 +1,15 @@
 name: Backport
 
 on:
-  pull_request:
+  # NOTE(negz): This is a risky target, but we run this action only when and if
+  # a PR is closed, then filter down to specifically merged PRs. We also don't
+  # invoke any scripts, etc from within the repo. I believe the fact that we'll
+  # be able to review PRs before this runs makes this fairly safe.
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
     types: [closed]
+  issue_comment:
+    types: [created]
 
 jobs:
   # NOTE(negz): I tested many backport GitHub actions before landing on this
@@ -12,17 +19,43 @@ jobs:
   # The main gotchas with this action are that it _only_ supports merge commits,
   # and that PRs _must_ be labelled before they're merged to trigger a backport.
   open-pr:
-    name: 
     runs-on: ubuntu-18.04
-    if: github.event.pull_request.merged
+    if: >
+      (
+        github.event_name == 'pull_request_target'
+        && github.event.pull_request.merged
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/backport')
+      )
     steps:
+      - name: React to Command
+        uses: actions/github-script@v4
+        if: >
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          startsWith(github.event.comment.body, '/backport')
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Ack that we saw the comment.
+            github.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: "eyes"
+            })
+            console.log("Reacted to comment.")
+
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Open Backport PR
-        uses: zeebe-io/backport-action@fffca395ae6b8ebad6799624ef9bac77b6c907c3
+        uses: zeebe-io/backport-action@v0.0.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_workspace: ${{ github.workspace }}
-          version: fffca395ae6b8ebad6799624ef9bac77b6c907c3
+          version: v0.0.4

--- a/workflow-templates/commands.yml
+++ b/workflow-templates/commands.yml
@@ -5,7 +5,7 @@ on: issue_comment
 jobs:
   points:
     runs-on: ubuntu-18.04
-    if: ${{ startsWith(github.event.comment.body, '/points') }}
+    if: startsWith(github.event.comment.body, '/points')
 
     steps:
     - name: Handle Command
@@ -59,3 +59,35 @@ jobs:
             labels: [points]
           })
           console.log("Added '" + points + "' label.")
+
+  # NOTE(negz): See also backport.yml, which is the variant that triggers on PR
+  # merge rather than on comment.
+  backport:
+    runs-on: ubuntu-18.04
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/backport')
+    steps:
+      - name: React to Command
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Ack that we saw the comment.
+            github.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: "eyes"
+            })
+            console.log("Reacted to comment.")
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Open Backport PR
+        uses: zeebe-io/backport-action@v0.0.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_workspace: ${{ github.workspace }}
+          version: v0.0.4


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

This PR enables support for backporting PRs across forks. Doing so requires using the dangerous `pull_request_target` trigger - see my commentary in the workflow file.

The PR also

* Pins to the latest release of the backport action.
* Supports a /backport command which is useful to backport PRs that were merged before the label was added.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

I've used a throwaway repo to test that I can backport:

* A PR from a fork, on merge
* A PR from a branch, on merge
* A PR from a fork, on /backport comment