### PR TITLE
Restrict who many issue commands

### DIFF
--- a/workflow-templates/commands.yml
+++ b/workflow-templates/commands.yml
@@ -8,15 +8,26 @@ jobs:
     if: startsWith(github.event.comment.body, '/points')
 
     steps:
+    - name: Extract Command
+      id: command
+      uses: xt0rted/slash-command-action@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        command: points
+        reaction: "true"
+        reaction-type: "eyes"
+        allow-edits: "false"
+        permission-level: write
     - name: Handle Command
       uses: actions/github-script@v4
+      env:
+        POINTS: ${{ steps.command.outputs.command-arguments }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
+          const points = process.env.POINTS
 
-          const parts = context.payload.comment.body.split(" ")
-
-          if (parts.length !== 2 || isNaN(parseInt(parts[1]))) {
+          if (isNaN(parseInt(points))) {
             console.log("Malformed command - expected '/points <int>'")
             github.reactions.createForIssueComment({
               owner: context.repo.owner,
@@ -26,16 +37,7 @@ jobs:
             })
             return
           }
-          const points = "points/" + parts[1]
-
-          // Ack that we saw the comment.
-          github.reactions.createForIssueComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            comment_id: context.payload.comment.id,
-            content: "eyes"
-          })
-          console.log("Reacted to comment.")
+          const label = "points/" + points
 
           // Delete our needs-points-label label.
           try {
@@ -56,9 +58,9 @@ jobs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            labels: [points]
+            labels: [label]
           })
-          console.log("Added '" + points + "' label.")
+          console.log("Added '" + label + "' label.")
 
   # NOTE(negz): See also backport.yml, which is the variant that triggers on PR
   # merge rather than on comment.
@@ -66,28 +68,25 @@ jobs:
     runs-on: ubuntu-18.04
     if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/backport')
     steps:
-      - name: React to Command
-        uses: actions/github-script@v4
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            // Ack that we saw the comment.
-            github.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: "eyes"
-            })
-            console.log("Reacted to comment.")
+    - name: Extract Command
+      id: command
+      uses: xt0rted/slash-command-action@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        command: backport
+        reaction: "true"
+        reaction-type: "eyes"
+        allow-edits: "false"
+        permission-level: write
 
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
-      - name: Open Backport PR
-        uses: zeebe-io/backport-action@v0.0.4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          github_workspace: ${{ github.workspace }}
-          version: v0.0.4
+    - name: Open Backport PR
+      uses: zeebe-io/backport-action@v0.0.4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_workspace: ${{ github.workspace }}
+        version: v0.0.4


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

This commit PR updates the Comment Commands workflow to use an action that handles comment commands, because said action is able to ensure that the job will fail if the commenter doesn't have write access to the project.

Note that we still use the startsWith if condition on the job. This is because the slash-command-action would otherwise run and fail on every comment that did not contain a comment command. By keeping the startsWith filter the step should either run successfully (if the commenter has write access) or fail (if they don't).

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
I've tested this in my Actions playground repo. Note that I'm trusting the action's permissions work - I've only confirmed that /points and /backport work for folks with write+ permission to the repo.